### PR TITLE
Feature: Multiple assignees per task, with API access control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ next-env.d.ts
 
 
 database_setup.sql
+
+/sql

--- a/app/api/gemini/route.ts
+++ b/app/api/gemini/route.ts
@@ -1,20 +1,61 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { requireUser } from '../../../lib/auth/apiAuth';
 
+const MAX_PROMPT = 4000;
 
-export async function POST(req: Request) {
-    const { prompt } = await req.json();
+/** Per-user rate limit. In-memory, so it resets on redeploy and is per-instance.
+ *  Good enough to stop casual abuse; move to Upstash/Redis if you scale out. */
+const RATE_LIMIT = 20;
+const WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const hits = new Map<string, { count: number; resetAt: number }>();
 
-    try {
-        const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-        const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash'});
+function rateLimited(userId: string): boolean {
+  const now = Date.now();
+  const entry = hits.get(userId);
 
-        const result = await model.generateContent(prompt);
-        const plan = result.response.text();
+  if (!entry || now > entry.resetAt) {
+    hits.set(userId, { count: 1, resetAt: now + WINDOW_MS });
+    return false;
+  }
 
-        return NextResponse.json({ plan });
-    } catch(error) {
-        console.error('Error:', error);
-        return NextResponse.json({ error: 'Failed to generate response' }, { status: 500 });
-    }
+  entry.count += 1;
+  return entry.count > RATE_LIMIT;
+}
+
+// POST: generate a study plan. Requires a signed-in user — this endpoint spends
+// money against GEMINI_API_KEY, so it must never be open to the public.
+export async function POST(req: NextRequest) {
+  const auth = await requireUser(req);
+  if ('response' in auth) return auth.response;
+
+  if (rateLimited(auth.userId)) {
+    return NextResponse.json(
+      { error: 'Rate limit exceeded. Try again later.' },
+      { status: 429 }
+    );
+  }
+
+  const body = await req.json().catch(() => null);
+  const prompt = body?.prompt;
+
+  if (typeof prompt !== 'string' || !prompt.trim()) {
+    return NextResponse.json({ error: 'Missing prompt' }, { status: 400 });
+  }
+  if (prompt.length > MAX_PROMPT) {
+    return NextResponse.json({ error: 'Prompt too long' }, { status: 400 });
+  }
+
+  try {
+    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
+    const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' });
+
+    const result = await model.generateContent(prompt);
+    const plan = result.response.text();
+
+    return NextResponse.json({ plan });
+  } catch (error) {
+    console.error('Error:', error);
+    return NextResponse.json({ error: 'Failed to generate response' }, { status: 500 });
+  }
 }

--- a/app/api/spaces/create/route.ts
+++ b/app/api/spaces/create/route.ts
@@ -1,33 +1,41 @@
-import { NextRequest } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { NextRequest, NextResponse } from "next/server";
+import { requireUser } from "../../../../lib/auth/apiAuth";
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
-
+// POST: create a space. The creator is taken from the session, not the body.
 export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const { name, code, userId } = body;
-  if (!name || !code || !userId) {
-    return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
+  const auth = await requireUser(req);
+  if ("response" in auth) return auth.response;
+
+  const body = await req.json().catch(() => null);
+  const name = body?.name;
+  const code = body?.code;
+
+  if (typeof name !== "string" || !name.trim() || typeof code !== "string" || !code.trim()) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+  if (name.length > 100 || code.length > 32) {
+    return NextResponse.json({ error: "Name or code too long" }, { status: 400 });
   }
 
-  // Create Space
-  const { data: space, error: spaceError } = await supabase
-    .from('tbl_spaces')
-    .insert([{ name, code, created_by: userId }])
+  const { data: space, error: spaceError } = await auth.supabase
+    .from("tbl_spaces")
+    .insert([{ name: name.trim(), code: code.trim(), created_by: auth.userId }])
     .select()
     .single();
+
   if (spaceError) {
-    console.error('Supabase space insert error:', spaceError);
-    return new Response(JSON.stringify({ error: spaceError.message }), { status: 500 });
+    console.error("Supabase space insert error:", spaceError);
+    return NextResponse.json({ error: spaceError.message }, { status: 500 });
   }
 
-  // Add Creator as Member
-  const { error: memberError } = await supabase
-    .from('tbl_space_members')
-    .insert([{ user_id: userId, space_id: space.id, role: 'admin' }]);
+  // Add the creator as admin.
+  const { error: memberError } = await auth.supabase
+    .from("tbl_space_members")
+    .insert([{ user_id: auth.userId, space_id: space.id, role: "admin" }]);
+
   if (memberError) {
-    return new Response(JSON.stringify({ error: memberError.message }), { status: 500 });
+    return NextResponse.json({ error: memberError.message }, { status: 500 });
   }
 
-  return new Response(JSON.stringify({ space }), { status: 200 });
+  return NextResponse.json({ space }, { status: 200 });
 }

--- a/app/api/spaces/delete/route.ts
+++ b/app/api/spaces/delete/route.ts
@@ -1,24 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { requireSpaceAdmin } from '../../../../lib/auth/apiAuth';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-
+// DELETE: remove a space. Admins of that space only.
 export async function DELETE(request: NextRequest) {
   try {
     const { spaceId } = await request.json();
 
-    if (!spaceId) {
+    if (!spaceId || typeof spaceId !== 'string') {
       return NextResponse.json(
         { message: 'Space ID is required' },
         { status: 400 }
       );
     }
 
-    // Delete space (this will cascade delete related records)
-    const { error } = await supabase
+    const auth = await requireSpaceAdmin(request, spaceId);
+    if ('response' in auth) return auth.response;
+
+    // Cascades to members and tasks.
+    const { error } = await auth.supabase
       .from('tbl_spaces')
       .delete()
       .eq('id', spaceId);

--- a/app/api/spaces/join/route.ts
+++ b/app/api/spaces/join/route.ts
@@ -1,69 +1,68 @@
-import { NextRequest } from "next/server";
-import { createClient } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from "next/server";
+import { requireUser } from "../../../../lib/auth/apiAuth";
 import { sendWelcomeEmail } from "../../../../lib/emailSender/welcomeMember";
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
+// POST: join a space by code. Always enrolls the CALLER as a plain member —
+// the userId and role are never read from the request body.
+export async function POST(req: NextRequest) {
+  const auth = await requireUser(req);
+  if ("response" in auth) return auth.response;
 
-export async function POST(req: NextRequest){
- const body = await req.json();
- const { code, userId } = body;
-if (!code || !userId) {
-    return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
-  }
-   // Find space by code
-  const { data: space, error: spaceError } = await supabase
-    .from('tbl_spaces')
-    .select('id')
-    .eq('code', code)
-    .single();
-  if (spaceError || !space) {
-    return new Response(JSON.stringify({ error: 'Space not found' }), { status: 404 });
+  const body = await req.json().catch(() => null);
+  const code = body?.code;
+
+  if (typeof code !== "string" || !code.trim()) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
   }
 
-  // Check if already a member
-  const { data: member } = await supabase
-    .from('tbl_space_members')
-    .select('id')
-    .eq('user_id', userId)
-    .eq('space_id', space.id)
-    .single();
-  if (member) {
-    return new Response(JSON.stringify({ error: 'Already a member' }), { status: 409 });
-  }
+  // Resolving a code to a space requires reading tbl_spaces, which RLS hides
+  // from non-members. join_space_by_code is a SECURITY DEFINER function that
+  // performs the lookup and the enrollment atomically. See
+  // sql/01_security_hardening.sql section 10.
+  const { data: spaceId, error: joinError } = await auth.supabase.rpc(
+    "join_space_by_code",
+    { p_code: code.trim() }
+  );
 
-  // Add member
-  const { error: joinError } = await supabase
-    .from('tbl_space_members')
-    .insert([{ user_id: userId, space_id: space.id, role: 'member' }]);
   if (joinError) {
-    return new Response(JSON.stringify({ error: joinError.message }), { status: 500 });
+    const message = joinError.message ?? "";
+    if (message.includes("space not found")) {
+      return NextResponse.json({ error: "Space not found" }, { status: 404 });
+    }
+    console.error("Join space error:", joinError);
+    return NextResponse.json({ error: "Failed to join space" }, { status: 500 });
   }
 
-    // Fetch user email and space name for the welcome email
-    const { data: userData, error: userError } = await supabase
-      .from('profiles')
-      .select('email, full_name')
-      .eq('id', userId)
-      .single();
-    const { data: spaceData, error: spaceNameError } = await supabase
-      .from('tbl_spaces')
-      .select('name')
-      .eq('id', space.id)
+  if (!spaceId) {
+    return NextResponse.json({ error: "Space not found" }, { status: 404 });
+  }
+
+  // Welcome email. Never blocks the join.
+  try {
+    const { data: userData } = await auth.supabase
+      .from("profiles")
+      .select("email, full_name")
+      .eq("id", auth.userId)
       .single();
 
-    if (!userError && !spaceNameError && userData?.email && spaceData?.name) {
-      try {
-        await sendWelcomeEmail(
-          userData.email,
-          userData.full_name,
-          spaceData.name,
-          space.id,
-          '' // invitedBy, can be set to the admin's name if available
-        );
-      } catch (e) {
-        console.error('Failed to send welcome email:', e);
-      }
+    const { data: spaceData } = await auth.supabase
+      .from("tbl_spaces")
+      .select("name")
+      .eq("id", spaceId)
+      .single();
+
+    if (userData?.email && spaceData?.name) {
+      await sendWelcomeEmail(
+        userData.email,
+        userData.full_name,
+        spaceData.name,
+        spaceId,
+        ""
+      );
     }
+  } catch (e) {
+    console.error("Failed to send welcome email:", e);
+  }
 
-    return new Response(JSON.stringify({ success: true, spaceId: space.id }), { status: 200 });
+  return NextResponse.json({ success: true, spaceId }, { status: 200 });
 }

--- a/app/api/spaces/kick-member/route.ts
+++ b/app/api/spaces/kick-member/route.ts
@@ -1,11 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { requireSpaceAdmin } from '../../../../lib/auth/apiAuth';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-
+// DELETE: remove a member from a space. Admins only.
 export async function DELETE(request: NextRequest) {
   try {
     const { spaceId, userId } = await request.json();
@@ -17,8 +13,19 @@ export async function DELETE(request: NextRequest) {
       );
     }
 
-    // Remove member from space
-    const { error } = await supabase
+    const auth = await requireSpaceAdmin(request, spaceId);
+    if ('response' in auth) return auth.response;
+
+    // An admin cannot kick themselves; they should leave the space instead.
+    // This also prevents a space being left with no admin by accident.
+    if (userId === auth.userId) {
+      return NextResponse.json(
+        { message: 'Use "leave space" to remove yourself' },
+        { status: 400 }
+      );
+    }
+
+    const { error } = await auth.supabase
       .from('tbl_space_members')
       .delete()
       .eq('space_id', spaceId)

--- a/app/api/spaces/members/route.ts
+++ b/app/api/spaces/members/route.ts
@@ -1,24 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { requireSpaceMember } from "../../../../lib/auth/apiAuth";
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
-
-// note search params are use to fetch data
+// GET: roster of a space. Only members of that space may read it.
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const spaceId = searchParams.get("spaceId");
 
   if (!spaceId) {
-    return new Response(JSON.stringify({ error: 'Missing spaceId' }), { status: 400 });
+    return NextResponse.json({ error: "Missing spaceId" }, { status: 400 });
   }
 
-    // Get members of the space, including their role
-  const { data, error } = await supabase
-    .from('tbl_space_members')
-      .select('user_id, role, tbl_users(id, full_name)')
-    .eq('space_id', spaceId);
+  const auth = await requireSpaceMember(req, spaceId);
+  if ("response" in auth) return auth.response;
+
+  // Names only. Emails are never exposed to other members.
+  const { data, error } = await auth.supabase
+    .from("tbl_space_members")
+    .select("user_id, role, tbl_users(id, full_name)")
+    .eq("space_id", spaceId);
+
   if (error) {
-    return new Response(JSON.stringify({ error: error.message }), { status: 500 });
+    return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
   return NextResponse.json({ members: data }, { status: 200 });

--- a/app/api/spaces/tasks/route.ts
+++ b/app/api/spaces/tasks/route.ts
@@ -1,12 +1,193 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { sendAssignmentEmail } from "../../../../lib/emailSender/sendAssignment";
 import { sendDeadlineReminderEmail } from "../../../../lib/emailSender/deadlineReminder";
+import {
+  getAuthedClient,
+  requireSpaceMember,
+  requireTaskAccess,
+  unauthorized,
+} from "../../../../lib/auth/apiAuth";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+/** Task fields a client is allowed to set. Anything else in the body is dropped. */
+const PRIORITIES = ["low", "moderate", "high"] as const;
+const KANBAN_STATUSES = ["todo", "in_progress", "done"] as const;
+
+const isPriority = (v: unknown): v is (typeof PRIORITIES)[number] =>
+  typeof v === "string" && (PRIORITIES as readonly string[]).includes(v);
+
+const isKanbanStatus = (v: unknown): v is (typeof KANBAN_STATUSES)[number] =>
+  typeof v === "string" && (KANBAN_STATUSES as readonly string[]).includes(v);
+
+const MAX_TITLE = 200;
+const MAX_DESCRIPTION = 10_000;
+
+/** Coerces the incoming assignee field into a clean, de-duplicated id array. */
+function parseAssignees(body: Record<string, unknown>): string[] | undefined {
+  const raw = body.assignees ?? body.assigned_to;
+  if (raw === undefined) return undefined;
+  if (raw === null) return [];
+
+  const list = Array.isArray(raw) ? raw : [raw];
+  const ids = list.filter(
+    (id): id is string => typeof id === "string" && id.trim().length > 0
+  );
+  return Array.from(new Set(ids));
+}
+
+/** Replaces a task's assignee set, returning the ids that are newly added. */
+async function setAssignees(
+  supabase: ReturnType<typeof getAuthedClient>,
+  taskId: string,
+  spaceId: string,
+  assignees: string[],
+  actorId: string
+): Promise<{ added: string[]; error?: string }> {
+  // Only real members of this space may be assigned. This is what stops a
+  // caller from attaching an arbitrary user id to a task.
+  let valid: string[] = [];
+  if (assignees.length > 0) {
+    const { data: members, error: membersError } = await supabase
+      .from("tbl_space_members")
+      .select("user_id")
+      .eq("space_id", spaceId)
+      .in("user_id", assignees);
+
+    if (membersError) return { added: [], error: membersError.message };
+    valid = (members ?? []).map((m: { user_id: string }) => m.user_id);
+  }
+
+  const { data: existingRows, error: existingError } = await supabase
+    .from("tbl_task_assignees")
+    .select("user_id")
+    .eq("task_id", taskId);
+
+  if (existingError) return { added: [], error: existingError.message };
+
+  const existing = (existingRows ?? []).map((r: { user_id: string }) => r.user_id);
+  const added = valid.filter((id) => !existing.includes(id));
+  const removed = existing.filter((id) => !valid.includes(id));
+
+  if (removed.length > 0) {
+    const { error } = await supabase
+      .from("tbl_task_assignees")
+      .delete()
+      .eq("task_id", taskId)
+      .in("user_id", removed);
+    if (error) return { added: [], error: error.message };
+  }
+
+  if (added.length > 0) {
+    const { error } = await supabase.from("tbl_task_assignees").insert(
+      added.map((userId) => ({
+        task_id: taskId,
+        user_id: userId,
+        assigned_by: actorId,
+      }))
+    );
+    if (error) return { added: [], error: error.message };
+  }
+
+  return { added };
+}
+
+/** Attaches an `assignees: string[]` array to each task row. */
+async function withAssignees(
+  supabase: ReturnType<typeof getAuthedClient>,
+  tasks: Array<Record<string, any>>
+) {
+  if (tasks.length === 0) return tasks;
+
+  const { data: rows } = await supabase
+    .from("tbl_task_assignees")
+    .select("task_id, user_id")
+    .in(
+      "task_id",
+      tasks.map((t) => t.id)
+    );
+
+  const byTask = new Map<string, string[]>();
+  for (const row of rows ?? []) {
+    const list = byTask.get(row.task_id) ?? [];
+    list.push(row.user_id);
+    byTask.set(row.task_id, list);
+  }
+
+  return tasks.map((task) => ({
+    ...task,
+    assignees: byTask.get(task.id) ?? [],
+  }));
+}
+
+/** Fire-and-forget assignment notifications. Never blocks the response. */
+async function notifyAssignees(
+  supabase: ReturnType<typeof getAuthedClient>,
+  userIds: string[],
+  actorId: string,
+  taskTitle: string,
+  priority: string,
+  spaceId: string,
+  deadline?: string | null
+) {
+  if (userIds.length === 0) return;
+  if (!process.env.GMAIL_USER || !process.env.GMAIL_PASS) {
+    console.error("GMAIL_USER or GMAIL_PASS not set, assignment emails skipped.");
+    return;
+  }
+
+  try {
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("id, email, full_name")
+      .in("id", [...userIds, actorId]);
+
+    const assignerName =
+      profiles?.find((p: { id: string }) => p.id === actorId)?.full_name ?? "Unknown";
+
+    let spaceName = "";
+    if (deadline) {
+      const { data: spaceData } = await supabase
+        .from("tbl_spaces")
+        .select("name")
+        .eq("id", spaceId)
+        .single();
+      spaceName = spaceData?.name ?? "";
+    }
+
+    const today = new Date().toISOString().split("T")[0];
+
+    await Promise.allSettled(
+      userIds.map(async (userId) => {
+        const profile = profiles?.find((p: { id: string }) => p.id === userId);
+        if (!profile?.email) return;
+
+        await sendAssignmentEmail(
+          profile.email,
+          profile.full_name,
+          taskTitle,
+          assignerName,
+          priority,
+          spaceId
+        );
+
+        if (deadline) {
+          const deadlineDate = new Date(deadline).toISOString().split("T")[0];
+          if (deadlineDate === today) {
+            await sendDeadlineReminderEmail(
+              profile.email,
+              profile.full_name,
+              taskTitle,
+              deadlineDate,
+              spaceName,
+              spaceId
+            );
+          }
+        }
+      })
+    );
+  } catch (emailErr) {
+    console.error("Email send error:", emailErr);
+  }
+}
 
 // GET: Fetch all tasks for a space
 export async function GET(request: NextRequest) {
@@ -16,6 +197,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Missing spaceId" }, { status: 400 });
   }
 
+  const auth = await requireSpaceMember(request, spaceId);
+  if ("response" in auth) return auth.response;
+  const { supabase } = auth;
+
   const { data, error } = await supabase
     .from("tbl_tasks")
     .select("*")
@@ -24,7 +209,11 @@ export async function GET(request: NextRequest) {
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
-  return NextResponse.json({ tasks: data }, { status: 200 });
+
+  return NextResponse.json(
+    { tasks: await withAssignees(supabase, data ?? []) },
+    { status: 200 }
+  );
 }
 
 // POST: Create a new task
@@ -34,153 +223,224 @@ export async function POST(request: NextRequest) {
   if (!spaceId) {
     return NextResponse.json({ error: "Missing spaceId" }, { status: 400 });
   }
-  const body = await request.json();
-  const { title, description, assigned_to, created_by, status, deadline } = body;
-  if (!title || !created_by) {
-    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+
+  const auth = await requireSpaceMember(request, spaceId);
+  if ("response" in auth) return auth.response;
+  const { supabase, userId } = auth;
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
   }
+
+  const { title, description, status, deadline, kanban_status } = body;
+  const assignees = parseAssignees(body) ?? [];
+
+  if (typeof description !== "string" || description.trim().length === 0) {
+    return NextResponse.json({ error: "Missing description" }, { status: 400 });
+  }
+  if (description.length > MAX_DESCRIPTION) {
+    return NextResponse.json({ error: "Description too long" }, { status: 400 });
+  }
+  if (title != null && (typeof title !== "string" || title.length > MAX_TITLE)) {
+    return NextResponse.json({ error: "Invalid title" }, { status: 400 });
+  }
+  if (status !== undefined && status !== null && !isPriority(status)) {
+    return NextResponse.json({ error: "Invalid priority" }, { status: 400 });
+  }
+  if (
+    kanban_status !== undefined &&
+    kanban_status !== null &&
+    !isKanbanStatus(kanban_status)
+  ) {
+    return NextResponse.json({ error: "Invalid kanban status" }, { status: 400 });
+  }
+
+  // created_by comes from the verified session, never from the request body.
   const { data, error } = await supabase
     .from("tbl_tasks")
-    .insert([{ space_id: spaceId, title, description, assigned_to, created_by, status, deadline }]);
+    .insert([
+      {
+        space_id: spaceId,
+        title: title ?? null,
+        description,
+        created_by: userId,
+        status: status ?? "low",
+        kanban_status: kanban_status ?? "todo",
+        deadline: deadline ?? null,
+      },
+    ])
+    .select()
+    .single();
+
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-    if (assigned_to) {
-    try {
-      const { data: userProfile } = await supabase
-        .from('profiles')
-        .select('email, full_name')
-        .eq('id', assigned_to)
-        .single();
-      let assignerName = 'Unknown';
-      if (created_by) {
-        const { data: assignerProfile } = await supabase
-          .from('profiles')
-          .select('full_name')
-          .eq('id', created_by)
-          .single();
-        if (assignerProfile?.full_name) {
-          assignerName = assignerProfile.full_name;
-        }
-      }
-      if (userProfile?.email && process.env.GMAIL_USER && process.env.GMAIL_PASS) {
-        await sendAssignmentEmail(userProfile.email, userProfile.full_name, title, assignerName, status, spaceId);
-      } else {
-        console.error('GMAIL_USER or GMAIL_PASS not set, email not sent.', error);
-      }
-    } catch (emailErr) {
-      console.error('Email send error:', emailErr);
-    }
+  const { added, error: assignError } = await setAssignees(
+    supabase,
+    data.id,
+    spaceId,
+    assignees,
+    userId
+  );
+  if (assignError) {
+    return NextResponse.json({ error: assignError }, { status: 500 });
   }
 
-  return NextResponse.json({ task: data }, { status: 200 });
+  await notifyAssignees(
+    supabase,
+    added,
+    userId,
+    title ?? description.slice(0, 80),
+    status ?? "low",
+    spaceId,
+    deadline ?? null
+  );
+
+  return NextResponse.json(
+    { task: { ...data, assignees: added } },
+    { status: 200 }
+  );
 }
 
 // PUT: Edit a task
 export async function PUT(request: NextRequest) {
-  const body = await request.json();
-  const { id, title, description, status, assigned_to, created_by, deadline, kanban_status } = body;
-  if (!id) {
-    return NextResponse.json({ error: "Missing task id" }, { status: 400 });
-  }
-  const updateFields: any = {};
-  if (title !== undefined) updateFields.title = title;
-  if (description !== undefined) updateFields.description = description;
-  if (status !== undefined) updateFields.status = status;
-  if (assigned_to !== undefined) updateFields.assigned_to = assigned_to;
-  if (deadline !== undefined) updateFields.deadline = deadline;
-  if (kanban_status !== undefined) updateFields.kanban_status = kanban_status;
-  const { data, error } = await supabase
-    .from("tbl_tasks")
-    .update(updateFields)
-    .eq("id", id);
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
   }
 
-  // Send assignment email if assigned_to is present
-  if (assigned_to) {
-    try {
-      const { data: userProfile } = await supabase
-        .from('profiles')
-        .select('email, full_name')
-        .eq('id', assigned_to)
-        .single();
-      let assignerName = 'Unknown';
-      if (created_by) {
-        const { data: assignerProfile } = await supabase
-          .from('profiles')
-          .select('full_name')
-          .eq('id', created_by)
-          .single();
-        if (assignerProfile?.full_name) {
-          assignerName = assignerProfile.full_name;
-        }
-      }
-      if (userProfile?.email && process.env.GMAIL_USER && process.env.GMAIL_PASS) {
-        await sendAssignmentEmail(userProfile.email, userProfile.full_name, title ?? '', assignerName, status ?? '', id);
-        // Send deadline reminder email if deadline is today
-        if (deadline) {
-          const today = new Date().toISOString().split('T')[0];
-          const deadlineDate = new Date(deadline).toISOString().split('T')[0];
-          if (deadlineDate === today) {
-            // Fetch space name
-            let spaceName = '';
-            if (id) {
-              const { data: taskData } = await supabase
-                .from('tbl_tasks')
-                .select('space_id')
-                .eq('id', id)
-                .single();
-              if (taskData?.space_id) {
-                const { data: spaceData } = await supabase
-                  .from('tbl_spaces')
-                  .select('name')
-                  .eq('id', taskData.space_id)
-                  .single();
-                if (spaceData?.name) {
-                  spaceName = spaceData.name;
-                }
-              }
-            }
-            await sendDeadlineReminderEmail(
-              userProfile.email,
-              userProfile.full_name,
-              title ?? '',
-              deadlineDate,
-              spaceName,
-              id
-            );
-          }
-        }
-      } else {
-        console.error('GMAIL_USER or GMAIL_PASS not set, email not sent.', error);
-      }
-    } catch (emailErr) {
-      console.error('Email send error:', emailErr);
+  const { id, title, description, status, deadline, kanban_status } = body;
+  if (!id || typeof id !== "string") {
+    return NextResponse.json({ error: "Missing task id" }, { status: 400 });
+  }
+
+  const auth = await requireTaskAccess(request, id);
+  if ("response" in auth) return auth.response;
+  const { supabase, userId, spaceId } = auth;
+
+  const updateFields: Record<string, unknown> = {};
+
+  if (title !== undefined) {
+    if (title !== null && (typeof title !== "string" || title.length > MAX_TITLE)) {
+      return NextResponse.json({ error: "Invalid title" }, { status: 400 });
+    }
+    updateFields.title = title;
+  }
+  if (description !== undefined) {
+    if (typeof description !== "string" || description.length > MAX_DESCRIPTION) {
+      return NextResponse.json({ error: "Invalid description" }, { status: 400 });
+    }
+    updateFields.description = description;
+  }
+  if (status !== undefined) {
+    if (!isPriority(status)) {
+      return NextResponse.json({ error: "Invalid priority" }, { status: 400 });
+    }
+    updateFields.status = status;
+  }
+  if (kanban_status !== undefined) {
+    if (!isKanbanStatus(kanban_status)) {
+      return NextResponse.json({ error: "Invalid kanban status" }, { status: 400 });
+    }
+    updateFields.kanban_status = kanban_status;
+  }
+  if (deadline !== undefined) {
+    updateFields.deadline = deadline;
+  }
+
+  if (Object.keys(updateFields).length > 0) {
+    const { error } = await supabase
+      .from("tbl_tasks")
+      .update(updateFields)
+      .eq("id", id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
     }
   }
 
-  return NextResponse.json({ task: data }, { status: 200 });
+  // Only touch assignments when the client actually sent the field, so a
+  // partial update (a kanban drag, say) does not wipe the assignee list.
+  let added: string[] = [];
+  const assignees = parseAssignees(body);
+  if (assignees !== undefined) {
+    const result = await setAssignees(supabase, id, spaceId, assignees, userId);
+    if (result.error) {
+      return NextResponse.json({ error: result.error }, { status: 500 });
+    }
+    added = result.added;
+  }
+
+  await notifyAssignees(
+    supabase,
+    added,
+    userId,
+    typeof title === "string" ? title : "",
+    isPriority(status) ? status : "low",
+    spaceId,
+    deadline ?? null
+  );
+
+  const { data: updated } = await supabase
+    .from("tbl_tasks")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  const [task] = await withAssignees(supabase, updated ? [updated] : []);
+  return NextResponse.json({ task }, { status: 200 });
 }
 
 // DELETE: Delete a task
 export async function DELETE(request: NextRequest) {
-  const body = await request.json();
-  const { id, ids } = body;
-  if (!id && !ids) {
+  const body = await request.json().catch(() => null);
+  const { id, ids } = body ?? {};
+
+  // Accepts a single id or an array for bulk delete.
+  const targets: string[] = Array.isArray(ids)
+    ? ids.filter((v): v is string => typeof v === "string" && v.length > 0)
+    : typeof id === "string" && id.length > 0
+    ? [id]
+    : [];
+
+  if (targets.length === 0) {
     return NextResponse.json({ error: "Missing task id or ids" }, { status: 400 });
   }
-  const query = supabase.from("tbl_tasks").delete();
-  if (ids && Array.isArray(ids)) {
-    query.in("id", ids);
-  } else {
-    query.eq("id", id);
+
+  // Authorize the first target to establish the caller's space, then confirm
+  // every remaining id belongs to that same space. Without this, one authorized
+  // id would be enough to delete tasks anywhere.
+  const auth = await requireTaskAccess(request, targets[0]);
+  if ("response" in auth) return auth.response;
+  const { supabase, spaceId } = auth;
+
+  const { data: owned, error: lookupError } = await supabase
+    .from("tbl_tasks")
+    .select("id")
+    .eq("space_id", spaceId)
+    .in("id", targets);
+
+  if (lookupError) {
+    return NextResponse.json({ error: lookupError.message }, { status: 500 });
   }
-  const { error } = await query;
+  if ((owned?.length ?? 0) !== targets.length) {
+    return NextResponse.json(
+      { error: "One or more tasks are not accessible" },
+      { status: 403 }
+    );
+  }
+
+  // tbl_task_assignees cascades on task delete.
+  const { error } = await supabase
+    .from("tbl_tasks")
+    .delete()
+    .eq("space_id", spaceId)
+    .in("id", targets);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
+
   return NextResponse.json({ success: true }, { status: 200 });
 }

--- a/app/api/spaces/update-member-role/route.ts
+++ b/app/api/spaces/update-member-role/route.ts
@@ -1,11 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { requireSpaceAdmin } from '../../../../lib/auth/apiAuth';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-
+// PUT: change a member's role. Admins only.
 export async function PUT(request: NextRequest) {
   try {
     const { spaceId, userId, role } = await request.json();
@@ -24,8 +20,28 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    // Update member role
-    const { error } = await supabase
+    const auth = await requireSpaceAdmin(request, spaceId);
+    if ('response' in auth) return auth.response;
+
+    // Refuse to demote the last admin, which would strand the space with
+    // nobody able to manage it.
+    if (role === 'member') {
+      const { data: admins } = await auth.supabase
+        .from('tbl_space_members')
+        .select('user_id')
+        .eq('space_id', spaceId)
+        .eq('role', 'admin');
+
+      const adminIds = (admins ?? []).map((a: { user_id: string }) => a.user_id);
+      if (adminIds.length <= 1 && adminIds.includes(userId)) {
+        return NextResponse.json(
+          { message: 'Cannot demote the last admin of a space' },
+          { status: 400 }
+        );
+      }
+    }
+
+    const { error } = await auth.supabase
       .from('tbl_space_members')
       .update({ role })
       .eq('space_id', spaceId)

--- a/app/api/spaces/update-name/route.ts
+++ b/app/api/spaces/update-name/route.ts
@@ -1,11 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { requireSpaceAdmin } from '../../../../lib/auth/apiAuth';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-
+// PUT: rename a space. Admins only.
 export async function PUT(request: NextRequest) {
   try {
     const { spaceId, newName } = await request.json();
@@ -17,8 +13,14 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    // Update space name
-    const { error } = await supabase
+    if (typeof newName !== 'string' || newName.length > 100) {
+      return NextResponse.json({ message: 'Invalid name' }, { status: 400 });
+    }
+
+    const auth = await requireSpaceAdmin(request, spaceId);
+    if ('response' in auth) return auth.response;
+
+    const { error } = await auth.supabase
       .from('tbl_spaces')
       .update({ name: newName.trim() })
       .eq('id', spaceId);

--- a/app/api/spaces/user-spaces/route.ts
+++ b/app/api/spaces/user-spaces/route.ts
@@ -1,23 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import {
+  requireUser,
+  requireSpaceAdmin,
+  requireSpaceMember,
+} from "../../../../lib/auth/apiAuth";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-
-// Get Space Members 
+// GET: spaces the CALLER belongs to. The userId query param is ignored; the
+// identity comes from the session so one user cannot enumerate another's spaces.
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const userId = searchParams.get("userId");
-  if (!userId) {
-    return NextResponse.json({ error: "Missing userId" }, { status: 400 });
-  }
+  const auth = await requireUser(request);
+  if ("response" in auth) return auth.response;
 
-  const { data, error } = await supabase
+  const { data, error } = await auth.supabase
     .from("tbl_space_members")
     .select("space_id, tbl_spaces(name, code)")
-    .eq("user_id", userId);
+    .eq("user_id", auth.userId);
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -26,16 +23,22 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({ spaces: data }, { status: 200 });
 }
 
-// Update Space Name
+// PUT: rename a space. Admins only.
 export async function PUT(request: NextRequest) {
   const body = await request.json();
   const { spaceId, name } = body;
 
-  if (!spaceId || !name) {
+  if (!spaceId || !name || typeof name !== "string") {
     return NextResponse.json({ error: "Missing spaceId or name" }, { status: 400 });
   }
+  if (name.length > 100) {
+    return NextResponse.json({ error: "Name too long" }, { status: 400 });
+  }
 
-  const { error } = await supabase
+  const auth = await requireSpaceAdmin(request, spaceId);
+  if ("response" in auth) return auth.response;
+
+  const { error } = await auth.supabase
     .from("tbl_spaces")
     .update({ name })
     .eq("id", spaceId);
@@ -47,17 +50,20 @@ export async function PUT(request: NextRequest) {
   return NextResponse.json({ message: "Space name updated" }, { status: 200 });
 }
 
-// Delte Space Name 
+// DELETE: delete a space (admin) or leave one (self).
 export async function DELETE(request: NextRequest) {
   const body = await request.json();
-  const { spaceId, userId, action } = body;
+  const { spaceId, action } = body;
 
-  if (!spaceId || !userId || !action) {
+  if (!spaceId || !action) {
     return NextResponse.json({ error: "Missing parameters" }, { status: 400 });
   }
 
   if (action === "delete_space") {
-    const { error } = await supabase
+    const auth = await requireSpaceAdmin(request, spaceId);
+    if ("response" in auth) return auth.response;
+
+    const { error } = await auth.supabase
       .from("tbl_spaces")
       .delete()
       .eq("id", spaceId);
@@ -70,11 +76,16 @@ export async function DELETE(request: NextRequest) {
   }
 
   if (action === "leave_space") {
-    const { error } = await supabase
+    const auth = await requireSpaceMember(request, spaceId);
+    if ("response" in auth) return auth.response;
+
+    // Always removes the CALLER. A userId in the body is ignored, so this
+    // cannot be used to evict somebody else.
+    const { error } = await auth.supabase
       .from("tbl_space_members")
       .delete()
       .eq("space_id", spaceId)
-      .eq("user_id", userId);
+      .eq("user_id", auth.userId);
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
@@ -86,7 +97,7 @@ export async function DELETE(request: NextRequest) {
   return NextResponse.json({ error: "Invalid action" }, { status: 400 });
 }
 
-// Update Member Role
+// PATCH: toggle a member's admin flag. Admins only.
 export async function PATCH(request: NextRequest) {
   const body = await request.json();
   const { spaceId, memberId, makeAdmin } = body;
@@ -95,9 +106,12 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: "Missing parameters" }, { status: 400 });
   }
 
-  const { error } = await supabase
+  const auth = await requireSpaceAdmin(request, spaceId);
+  if ("response" in auth) return auth.response;
+
+  const { error } = await auth.supabase
     .from("tbl_space_members")
-    .update({ is_admin: makeAdmin })
+    .update({ role: makeAdmin ? "admin" : "member" })
     .eq("space_id", spaceId)
     .eq("user_id", memberId);
 

--- a/app/components/DashboardBlocks/AddTaskModal.tsx
+++ b/app/components/DashboardBlocks/AddTaskModal.tsx
@@ -3,8 +3,9 @@
 import React, { useState } from 'react';
 import { Rocket, Clock, AlertCircle, Zap, X, BookOpen } from 'lucide-react';
 import { Priority } from '../../types/dashboard';
-import { Member, AddTaskModalProps } from '../../types/join-space';
+import { AddTaskModalProps } from '../../types/join-space';
 import { useStudyPlannerContext } from '../../contexts/StudyPlannerContext';
+import AssigneeSelect from './AssigneeSelect';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 
@@ -20,21 +21,21 @@ const AddTaskModal: React.FC<AddTaskModalProps> = ({
   handleAddTask,
   setShowInput,
   members,
-  assignedTo,
-  setAssignedTo,
+  assignees,
+  setAssignees,
   setDeadline,
 }) => {
   const [isScrolling, setIsScrolling] = useState(false);
   const [scrollTimeout, setScrollTimeout] = useState<NodeJS.Timeout | null>(null);
   const [showEmptyError, setShowEmptyError] = useState(false);
-  const [localAssignedTo, setLocalAssignedTo] = useState<string | null>(null);
+  const [localAssignees, setLocalAssignees] = useState<string[]>([]);
   const [showAIPlan, setShowAIPlan] = useState(false);
-  
+
   // Use the Study Planner Context
   const { aiPlan, planTitle, setAiPlan, setSelectedType } = useStudyPlannerContext();
-  
-  const effectiveAssignedTo = typeof assignedTo !== 'undefined' ? assignedTo : localAssignedTo;
-  const effectiveSetAssignedTo = typeof setAssignedTo !== 'undefined' ? setAssignedTo : setLocalAssignedTo;
+
+  const effectiveAssignees = typeof assignees !== 'undefined' ? assignees : localAssignees;
+  const effectiveSetAssignees = typeof setAssignees !== 'undefined' ? setAssignees : setLocalAssignees;
 
   if (!showInput) return null;
 
@@ -59,7 +60,7 @@ const AddTaskModal: React.FC<AddTaskModalProps> = ({
       return;
     }
     setShowEmptyError(false);
-  handleAddTask(e, effectiveAssignedTo ?? null);
+    handleAddTask(e, effectiveAssignees);
   };
 
   return (
@@ -123,26 +124,16 @@ const AddTaskModal: React.FC<AddTaskModalProps> = ({
               />
             </div>
 
-            {/* Only show assign dropdown if members prop is provided (space page) */}
+            {/* Assignees. Only rendered on the space page, where members exist. */}
             {typeof members !== 'undefined' && Array.isArray(members) && members.length > 0 && (
-              <select
-                value={effectiveAssignedTo ?? ""}
-                onChange={e => effectiveSetAssignedTo(e.target.value)}
-                className="w-full p-2 rounded-lg bg-gray-800 text-white mb-3 p-2 px-2 font-poppins"
-              >
-                <option value="">Assign to...</option>
-                {members.map((member: Member) => {
-                  // Safely cast tbl_users to expected shape
-                  const user = Array.isArray(member.tbl_users)
-                    ? member.tbl_users[0] as { id?: string; full_name?: string }
-                    : member.tbl_users as { id?: string; full_name?: string };
-                  return user && typeof user.id === 'string' ? (
-                    <option key={user.id} value={user.id}>
-                      {user.full_name ?? 'Unnamed Member'}
-                    </option>
-                  ) : null;
-                })}
-              </select>
+              <div className="mb-3">
+                <AssigneeSelect
+                  members={members}
+                  value={effectiveAssignees}
+                  onChange={effectiveSetAssignees}
+                  label="Assign to (one or more)"
+                />
+              </div>
             )}
             {/* Content Textarea */}
             <textarea

--- a/app/components/DashboardBlocks/AssigneeSelect.tsx
+++ b/app/components/DashboardBlocks/AssigneeSelect.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Check, ChevronDown, User, X } from 'lucide-react';
+import { Member, memberUser } from '../../types/join-space';
+
+interface AssigneeSelectProps {
+  members: Member[];
+  /** Selected user ids. */
+  value: string[];
+  onChange: (ids: string[]) => void;
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Multi-select for task assignees. Renders selected people as removable chips
+ * over a checkbox dropdown, so one task can be assigned to any number of
+ * members of the space.
+ */
+const AssigneeSelect: React.FC<AssigneeSelectProps> = ({
+  members,
+  value,
+  onChange,
+  label = 'Assign to',
+  className = '',
+}) => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click and on Escape.
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  const options = members
+    .map((member) => {
+      const user = memberUser(member);
+      return user && typeof user.id === 'string'
+        ? { id: user.id, name: user.full_name ?? 'Unnamed Member' }
+        : null;
+    })
+    .filter((o): o is { id: string; name: string } => o !== null);
+
+  const nameFor = (id: string) => options.find((o) => o.id === id)?.name ?? 'Unknown';
+
+  const toggle = (id: string) => {
+    onChange(value.includes(id) ? value.filter((v) => v !== id) : [...value, id]);
+  };
+
+  const summary =
+    value.length === 0
+      ? 'Unassigned'
+      : value.length === 1
+      ? nameFor(value[0])
+      : `${value.length} people assigned`;
+
+  return (
+    <div ref={containerRef} className={`relative ${className}`}>
+      <label className="block text-white/70 text-xs sm:text-sm font-poppins mb-1">
+        {label}
+      </label>
+
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="w-full flex items-center justify-between gap-2 p-2 rounded-lg bg-gray-800 text-white font-poppins text-sm sm:text-base border border-white/10 hover:border-white/30 transition-colors"
+      >
+        <span className="flex items-center gap-2 truncate">
+          <User className="w-4 h-4 text-slate-400 shrink-0" />
+          <span className={`truncate ${value.length === 0 ? 'text-white/50' : ''}`}>
+            {summary}
+          </span>
+        </span>
+        <ChevronDown
+          className={`w-4 h-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {/* Selected chips */}
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-2">
+          {value.map((id) => (
+            <span
+              key={id}
+              className="flex items-center gap-1 px-2 py-1 rounded-full bg-sky-500/20 border border-sky-400/40 text-sky-200 text-xs font-poppins"
+            >
+              {nameFor(id)}
+              <button
+                type="button"
+                onClick={() => toggle(id)}
+                aria-label={`Remove ${nameFor(id)}`}
+                className="hover:text-white transition-colors"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {open && (
+        <div
+          role="listbox"
+          aria-multiselectable
+          className="absolute z-50 mt-2 w-full max-h-56 overflow-y-auto rounded-lg bg-gray-800 border border-white/20 shadow-2xl"
+        >
+          {options.length === 0 ? (
+            <p className="px-3 py-2 text-white/50 text-sm font-poppins">
+              No members in this space
+            </p>
+          ) : (
+            options.map((option) => {
+              const selected = value.includes(option.id);
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  onClick={() => toggle(option.id)}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm font-poppins text-white hover:bg-white/10 transition-colors"
+                >
+                  <span
+                    className={`w-4 h-4 shrink-0 rounded border flex items-center justify-center ${
+                      selected
+                        ? 'bg-sky-500 border-sky-400'
+                        : 'border-white/30'
+                    }`}
+                  >
+                    {selected && <Check className="w-3 h-3 text-white" />}
+                  </span>
+                  <span className="truncate">{option.name}</span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AssigneeSelect;

--- a/app/components/DashboardBlocks/EditTaskModal.tsx
+++ b/app/components/DashboardBlocks/EditTaskModal.tsx
@@ -4,13 +4,12 @@ import React, { useState, useEffect } from 'react';
 import { Check, Trash, Clock, Zap, AlertCircle } from 'lucide-react';
 import { EditTaskModalProps, Priority } from '../../types/dashboard';
 import { Member } from '../../types/join-space';
+import AssigneeSelect from './AssigneeSelect';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 
 const EditTaskModal: React.FC<EditTaskModalProps & {
   members?: Member[],
-  assignedTo?: string | null,
-  setAssignedTo?: (id: string | null) => void,
   editedPriority?: Priority,
   setEditedPriority?: (priority: Priority) => void,
   editedKanbanStatus?: 'todo' | 'in_progress' | 'done',
@@ -29,17 +28,17 @@ const EditTaskModal: React.FC<EditTaskModalProps & {
   setTodoToDelete,
   cancelEditing,
   members,
-  assignedTo,
-  setAssignedTo,
+  assignees,
+  setAssignees,
   editedPriority,
   setEditedPriority,
   editedKanbanStatus,
   setEditedKanbanStatus,
 }) => {
-  // Local state for assignment dropdown
-  const [localAssignedTo, setLocalAssignedTo] = useState<string | null>(assignedTo ?? null);
-  const effectiveAssignedTo = typeof assignedTo !== 'undefined' ? assignedTo : localAssignedTo;
-  const effectiveSetAssignedTo = typeof setAssignedTo !== 'undefined' ? setAssignedTo : setLocalAssignedTo;
+  // Local fallback when the parent does not own assignee state.
+  const [localAssignees, setLocalAssignees] = useState<string[]>(assignees ?? []);
+  const effectiveAssignees = typeof assignees !== 'undefined' ? assignees : localAssignees;
+  const effectiveSetAssignees = typeof setAssignees !== 'undefined' ? setAssignees : setLocalAssignees;
 
   // Local state for priority and kanban status
   const [localPriority, setLocalPriority] = useState<Priority>('low');
@@ -56,7 +55,7 @@ const EditTaskModal: React.FC<EditTaskModalProps & {
       }
     };
   }, [scrollTimeout]);
-9
+
   const todoIndex = todos.findIndex(todo => todo.id === editingTaskId);
   const editingTodo = todoIndex >= 0 ? todos[todoIndex] : null;
 
@@ -69,10 +68,14 @@ const EditTaskModal: React.FC<EditTaskModalProps & {
       } else {
         setEditedDeadline(null);
       }
-      if (typeof setAssignedTo !== 'undefined') {
-        setAssignedTo(editingTodo.assigned_to || null);
+      // Prefer the multi-assignee array, falling back to the legacy single
+      // column for tasks created before the migration.
+      const current = editingTodo.assignees
+        ?? (editingTodo.assigned_to ? [editingTodo.assigned_to] : []);
+      if (typeof setAssignees !== 'undefined') {
+        setAssignees(current);
       } else {
-        setLocalAssignedTo(editingTodo.assigned_to || null);
+        setLocalAssignees(current);
       }
 
       // Set priority
@@ -186,27 +189,15 @@ const EditTaskModal: React.FC<EditTaskModalProps & {
             </div>
           </div>
 
-          {/* Assignment Dropdown for space page */}
+          {/* Assignees. Only rendered on the space page, where members exist. */}
           {typeof members !== 'undefined' && Array.isArray(members) && members.length > 0 && (
             <div className="mb-3">
-              <label className="block text-white/70 text-xs sm:text-sm font-poppins mb-1">Assign to</label>
-              <select
-                value={effectiveAssignedTo ?? ""}
-                onChange={e => effectiveSetAssignedTo(e.target.value)}
-                className="w-full p-2 rounded-lg bg-gray-800 text-white font-poppins text-sm sm:text-base"
-              >
-                <option value="">Unassigned</option>
-                {members.map((member: Member) => {
-                  const user = Array.isArray(member.tbl_users)
-                    ? member.tbl_users[0] as { id?: string; full_name?: string }
-                    : member.tbl_users as { id?: string; full_name?: string };
-                  return user && typeof user.id === 'string' ? (
-                    <option key={user.id} value={user.id}>
-                      {user.full_name ?? 'Unnamed Member'}
-                    </option>
-                  ) : null;
-                })}
-              </select>
+              <AssigneeSelect
+                members={members}
+                value={effectiveAssignees}
+                onChange={effectiveSetAssignees}
+                label="Assign to (one or more)"
+              />
             </div>
           )}
           {/* Content Textarea */}

--- a/app/components/DashboardBlocks/KanbanBoard.tsx
+++ b/app/components/DashboardBlocks/KanbanBoard.tsx
@@ -259,13 +259,31 @@ const KanbanBoard: React.FC<KanbanBoardProps> = ({
                         </div>
                       )}
 
-                      {/* Assigned Member */}
-                      {showAssignedMember && task.assigned_member && (
-                        <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-black/40 border border-white/5 ml-auto">
-                          <User className="w-3 h-3 text-sky-400" />
-                          <span className="text-[10px] text-slate-400 font-bold font-poppins uppercase tracking-wider truncate max-w-[80px]">
-                            {task.assigned_member}
-                          </span>
+                      {/* Assigned members. Shows the first two by name and
+                          rolls the rest into a +N chip to keep cards compact. */}
+                      {showAssignedMember && (task.assigned_members?.length ?? 0) > 0 && (
+                        <div className="flex items-center gap-1.5 ml-auto min-w-0">
+                          {task.assigned_members!.slice(0, 2).map((name) => (
+                            <div
+                              key={name}
+                              className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-black/40 border border-white/5"
+                            >
+                              <User className="w-3 h-3 text-sky-400" />
+                              <span className="text-[10px] text-slate-400 font-bold font-poppins uppercase tracking-wider truncate max-w-[80px]">
+                                {name}
+                              </span>
+                            </div>
+                          ))}
+                          {task.assigned_members!.length > 2 && (
+                            <div
+                              className="flex items-center px-2.5 py-1 rounded-lg bg-black/40 border border-white/5"
+                              title={task.assigned_members!.slice(2).join(', ')}
+                            >
+                              <span className="text-[10px] text-slate-400 font-bold font-poppins uppercase tracking-wider">
+                                +{task.assigned_members!.length - 2}
+                              </span>
+                            </div>
+                          )}
                         </div>
                       )}
                     </div>

--- a/app/hooks/dashboard/useStudyPlanner.tsx
+++ b/app/hooks/dashboard/useStudyPlanner.tsx
@@ -86,10 +86,16 @@ const useStudyPlanner = ({ onClose, userId, spaceId, tableType = 'todos', openAd
   `;
 
     try {
+      const { data: { session } } = await supabase.auth.getSession();
       const res = await fetch("/api/gemini", {
         method: "POST",
         body: JSON.stringify({ prompt }),
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...(session?.access_token
+            ? { Authorization: `Bearer ${session.access_token}` }
+            : {}),
+        },
       });
       
       if (!res.ok) {

--- a/app/hooks/space/useSpaceSettings.tsx
+++ b/app/hooks/space/useSpaceSettings.tsx
@@ -3,6 +3,19 @@ import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useRouter } from 'next/navigation';
 import { SpaceSettingsHookProps, Member } from '../../types/space-settings';
+import { supabase } from '../../../lib/supabaseClient';
+
+/** JSON headers plus the caller's Supabase access token. Space admin actions
+ *  are authorized server-side from this token. */
+const authJsonHeaders = async (): Promise<Record<string, string>> => {
+  const { data: { session } } = await supabase.auth.getSession();
+  return {
+    'Content-Type': 'application/json',
+    ...(session?.access_token
+      ? { Authorization: `Bearer ${session.access_token}` }
+      : {}),
+  };
+};
 
 const useSpaceSettings = ({ 
   spaceId, 
@@ -36,9 +49,7 @@ const useSpaceSettings = ({
     try {
       const response = await fetch('/api/spaces/update-name', {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await authJsonHeaders(),
         body: JSON.stringify({
           spaceId,
           newName: newSpaceName.trim(),
@@ -70,9 +81,7 @@ const useSpaceSettings = ({
     try {
       const response = await fetch('/api/spaces/delete', {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await authJsonHeaders(),
         body: JSON.stringify({ spaceId }),
       });
 
@@ -101,9 +110,7 @@ const useSpaceSettings = ({
     try {
       const response = await fetch('/api/spaces/update-member-role', {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await authJsonHeaders(),
         body: JSON.stringify({
           spaceId,
           userId,
@@ -138,9 +145,7 @@ const useSpaceSettings = ({
     try {
       const response = await fetch('/api/spaces/kick-member', {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await authJsonHeaders(),
         body: JSON.stringify({
           spaceId,
           userId,

--- a/app/services/iskolarspace-api.ts
+++ b/app/services/iskolarspace-api.ts
@@ -1,15 +1,32 @@
 import axios from 'axios';
+import { supabase } from '../../lib/supabaseClient';
 
-// Create a space
-export const createSpace = async (name: string, code: string, userId: number) => {
-  const res = await axios.post('/api/spaces/create', { name, code, userId });
+/**
+ * Attaches the current Supabase access token to every API request. The server
+ * derives the caller's identity from this token; ids sent in a request body are
+ * not trusted. Requests made without a session will be rejected with a 401.
+ */
+const authHeaders = async () => {
+  const { data: { session } } = await supabase.auth.getSession();
+  return session?.access_token
+    ? { Authorization: `Bearer ${session.access_token}` }
+    : {};
+};
+
+// Create a space. The creator is taken from the session server-side.
+export const createSpace = async (name: string, code: string, _userId?: unknown) => {
+  const res = await axios.post('/api/spaces/create', { name, code }, {
+    headers: await authHeaders(),
+  });
   return res.data;
 };
 
-// Join a space
-export const joinSpace = async (code: string, userId: number) => {
+// Join a space by code. Always enrolls the signed-in user.
+export const joinSpace = async (code: string, _userId?: unknown) => {
   try {
-    const res = await axios.post('/api/spaces/join', { code, userId });
+    const res = await axios.post('/api/spaces/join', { code }, {
+      headers: await authHeaders(),
+    });
     return res.data;
   } catch (err: any) {
     if (err.response?.status === 409) {
@@ -19,63 +36,90 @@ export const joinSpace = async (code: string, userId: number) => {
   }
 };
 
-// Get all spaces the user has joined
-export const getUserSpaces = async (userId: number) => {
-  const res = await axios.get(`/api/spaces/user-spaces?userId=${userId}`);
+// Get all spaces the signed-in user has joined.
+export const getUserSpaces = async (_userId?: unknown) => {
+  const res = await axios.get('/api/spaces/user-spaces', {
+    headers: await authHeaders(),
+  });
   return res.data.spaces;
 };
 
 // Get all members in a space
 export const getSpaceMembers = async (spaceId: string) => {
-  const res = await axios.get(`/api/spaces/members?spaceId=${spaceId}`);
+  const res = await axios.get(`/api/spaces/members?spaceId=${spaceId}`, {
+    headers: await authHeaders(),
+  });
   return res.data.members;
 };
 
-// Get all tasks in a space
+// Get all tasks in a space. Each task carries an `assignees: string[]`.
 export const getTasks = async (spaceId: string) => {
-  const res = await axios.get(`/api/spaces/tasks?spaceId=${spaceId}`);
+  const res = await axios.get(`/api/spaces/tasks?spaceId=${spaceId}`, {
+    headers: await authHeaders(),
+  });
   return res.data.tasks;
 };
 
-// Create a task in a space
+// Create a task in a space. Pass `assignees` as an array of user ids.
 export const createTask = async (spaceId: string, task: any) => {
-  const res = await axios.post(`/api/spaces/tasks?spaceId=${spaceId}`, task);
+  const res = await axios.post(`/api/spaces/tasks?spaceId=${spaceId}`, task, {
+    headers: await authHeaders(),
+  });
   return res.data.task;
 };
 
-// Update a task in a space
+// Update a task in a space. Omit `assignees` to leave assignments untouched.
 export const updateTask = async (spaceId: string, task: any) => {
-  const res = await axios.put(`/api/spaces/tasks?spaceId=${spaceId}`, task);
+  const res = await axios.put(`/api/spaces/tasks?spaceId=${spaceId}`, task, {
+    headers: await authHeaders(),
+  });
   return res.data.task;
 };
 
-// Delete tasks in a space
+// Delete one or many tasks in a space
 export const deleteTask = async (spaceId: string, id: string | string[]) => {
   const payload = Array.isArray(id) ? { ids: id } : { id };
-  const res = await axios.delete(`/api/spaces/tasks?spaceId=${spaceId}`, { data: payload });
+  const res = await axios.delete(`/api/spaces/tasks?spaceId=${spaceId}`, {
+    data: payload,
+    headers: await authHeaders(),
+  });
   return res.data.success;
 };
 
-// Edit space name
+// Edit space name (admin only, enforced server-side)
 export const editSpaceName = async (spaceId: string, newName: string) => {
-  const res = await axios.put(`/api/spaces/user-spaces?spaceId=${spaceId}`, { name: newName });
+  const res = await axios.put('/api/spaces/user-spaces', { spaceId, name: newName }, {
+    headers: await authHeaders(),
+  });
   return res.data.space;
 };
 
-// Delete space
+// Delete space (admin only, enforced server-side)
 export const deleteSpace = async (spaceId: string) => {
-  const res = await axios.delete(`/api/spaces/user-spaces?spaceId=${spaceId}`);
+  const res = await axios.delete('/api/spaces/user-spaces', {
+    data: { spaceId, action: 'delete_space' },
+    headers: await authHeaders(),
+  });
   return res.data.success;
 };
 
-// Leave space
-export const leaveSpace = async (spaceId: string, userId: number) => {
-  const res = await axios.post(`/api/spaces/user-spaces`, { spaceId, userId });
+// Leave space. Always removes the signed-in user.
+export const leaveSpace = async (spaceId: string, _userId?: unknown) => {
+  const res = await axios.delete('/api/spaces/user-spaces', {
+    data: { spaceId, action: 'leave_space' },
+    headers: await authHeaders(),
+  });
   return res.data.success;
 };
 
-// Make a space member admin
-export const makeMemberAdmin = async (spaceId: string, memberId: number) => {
-  const res = await axios.post(`/api/spaces/user-spaces`, { spaceId, memberId });
+// Make a space member admin (admin only, enforced server-side)
+export const makeMemberAdmin = async (spaceId: string, memberId: string) => {
+  const res = await axios.patch('/api/spaces/user-spaces', {
+    spaceId,
+    memberId,
+    makeAdmin: true,
+  }, {
+    headers: await authHeaders(),
+  });
   return res.data.success;
 };

--- a/app/space/[space_id]/page.tsx
+++ b/app/space/[space_id]/page.tsx
@@ -10,7 +10,7 @@ import Sidebar from '../../components/DashboardBlocks/Sidebar';
 import SpaceBackground from '../../components/DashboardBlocks/SpaceBackground';
 import { getTasks, getSpaceMembers } from '../../services/iskolarspace-api';
 import { getUserSpaces } from '../../services/iskolarspace-api';
-import { createTask, updateTask, deleteTask } from '../../services/iskolarspace-api';
+import { createTask, updateTask, deleteTask, leaveSpace } from '../../services/iskolarspace-api';
 import { useAuth } from '../../hooks/auth/useAuth';
 import useSidebar from '../../hooks/dashboard/useSidebar';
 import LoadingSpinner from '../../components/DashboardBlocks/Loader';
@@ -79,7 +79,7 @@ const SpacePage = () => {
   const [task, setTask] = useState('');
   const [title, setTitle] = useState('');
   const [priority, setPriority] = useState<'low' | 'moderate' | 'high'>('low');
-  const [assignedTo, setAssignedTo] = useState<string | null>(null);
+  const [assignees, setAssignees] = useState<string[]>([]);
   const [deadline, setDeadline] = useState<Date | null>(null);
   const [updatingTask, setUpdatingTask] = useState(false);
 
@@ -123,7 +123,7 @@ const SpacePage = () => {
   }, [spaceId]);
 
   // Add task
-  const handleAddTask = async (e?: React.FormEvent<any>, assignedToArg?: string | null) => {
+  const handleAddTask = async (e?: React.FormEvent<any>, assigneesArg?: string[]) => {
     if (e) e.preventDefault();
     if (!task.trim() || !user?.id || !spaceId) return;
     let deadlineToSave = null;
@@ -133,12 +133,12 @@ const SpacePage = () => {
       deadlineToSave = noonDate.toISOString();
     }
     try {
+      // created_by is derived server-side from the session token.
       const result = await createTask(spaceId, {
         title: title.trim() || null,
         description: task,
         status: priority,
-        created_by: user.id,
-        assigned_to: assignedToArg === '' ? null : assignedToArg,
+        assignees: assigneesArg ?? assignees,
         deadline: deadlineToSave
       });
       toast.success('Task created successfully!');
@@ -146,7 +146,7 @@ const SpacePage = () => {
       setTitle('');
       setPriority('low');
       setShowInput(false);
-      setAssignedTo(null);
+      setAssignees([]);
       setDeadline(null);
       await fetchTasks(false);
     } catch (err: any) {
@@ -225,6 +225,7 @@ const SpacePage = () => {
   setEditedContent('');
   setEditedTitle('');
   setEditedPriority('low');
+  setAssignees([]);
   setShowEditModal(false);
   };
   const handleSaveEdit = async (taskId: string) => {
@@ -241,8 +242,7 @@ const SpacePage = () => {
         title: editedTitle.trim() || null,
         description: editedContent,
         status: editedPriority,
-        assigned_to: assignedTo === '' ? null : assignedTo,
-        created_by: user?.id,
+        assignees,
         deadline: editDeadlineToSave,
         kanban_status: editedKanbanStatus
       });
@@ -260,11 +260,10 @@ const SpacePage = () => {
     if (!taskToUpdate || !spaceId) return;
 
     try {
+      // Send only the field that changed. Omitted fields, assignees included,
+      // are left untouched by the API.
       await updateTask(spaceId, {
         id: taskId,
-        title: taskToUpdate.title || null,
-        description: taskToUpdate.description || taskToUpdate.content || '',
-        status: taskToUpdate.status || taskToUpdate.priority || 'low',
         kanban_status: newStatus,
       });
       await fetchTasks(false);
@@ -304,22 +303,12 @@ const SpacePage = () => {
     if (!userId || !spaceId) return;
     setLeaving(true);
     try {
-      // Use the leaveSpace API from services
-      // leaveSpace expects (spaceId: string, userId: number)
-      // It uses POST /api/spaces/user-spaces with { spaceId, userId, action: 'leave_space' }
-      const res = await fetch('/api/spaces/user-spaces', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ spaceId, userId, action: 'leave_space' }),
-      });
-      if (res.ok) {
-        toast.success('You have left the space.');
-        setShowSpaceInfoModal(false);
-        router.push('/dashboard'); 
-        // Optionally redirect or update UI here
-      } else {
-        toast.error('Failed to leave space.');
-      }
+      // Always removes the signed-in user; the server ignores any userId
+      // sent in the body.
+      await leaveSpace(spaceId);
+      toast.success('You have left the space.');
+      setShowSpaceInfoModal(false);
+      router.push('/dashboard');
     } catch (err) {
       toast.error('Error leaving space.');
     }
@@ -499,8 +488,8 @@ const SpacePage = () => {
                 setPriority={setPriority}
                 handleAddTask={handleAddTask}
                 setShowInput={setShowInput}
-                assignedTo={assignedTo}
-                setAssignedTo={setAssignedTo}
+                assignees={assignees}
+                setAssignees={setAssignees}
                 members={members}
               />
               <KanbanBoard
@@ -552,8 +541,12 @@ const SpacePage = () => {
                     ...task,
                     priority: (task.priority || task.status || 'low'),
                     content: task.content || task.description || '',
-                    assigned_to: task.assigned_to,
-                    assigned_member: members.find(m => m.tbl_users.id === task.assigned_to)?.tbl_users.full_name || 'Unassigned',
+                    assignees: task.assignees ?? [],
+                    assigned_members: (task.assignees ?? []).map(
+                      (id: string) =>
+                        members.find(m => m.tbl_users.id === id)?.tbl_users.full_name
+                        || 'Unknown member'
+                    ),
                     deadline: task.deadline || null,
                   }))
                 }
@@ -571,6 +564,7 @@ const SpacePage = () => {
                       content: task.content || task.description || '',
                       deadline: task.deadline || null,
                       kanban_status: task.kanban_status || 'todo',
+                      assignees: task.assignees ?? [],
                     }))}
                     editedContent={editedContent}
                     editedTitle={editedTitle}
@@ -580,8 +574,8 @@ const SpacePage = () => {
                     setShowDeleteModal={setShowDeleteModal}
                     setTodoToDelete={(id) => id && setTasksToDelete([id])}
                     cancelEditing={cancelEditing}
-                    assignedTo={assignedTo}
-                    setAssignedTo={setAssignedTo}
+                    assignees={assignees}
+                    setAssignees={setAssignees}
                     members={members}
                     editedDeadline={editedDeadline}
                     setEditedDeadline={setEditedDeadline}

--- a/app/types/dashboard.ts
+++ b/app/types/dashboard.ts
@@ -8,8 +8,14 @@ export interface Todo {
   user_id: string;
   created_at: string;
   priority: 'low' | 'moderate' | 'high';
+  /** @deprecated single-assignee column, kept for rollout. Use assignees. */
   assigned_to?: string;
+  /** @deprecated single-assignee display name. Use assigned_members. */
   assigned_member?: string;
+  /** User ids of everyone assigned to this task. */
+  assignees?: string[];
+  /** Display names resolved from assignees, in the same order. */
+  assigned_members?: string[];
   deadline?: string | Date | null;
   tableType?: 'todos' | 'tasks';
   kanban_status?: 'todo' | 'in_progress' | 'done';
@@ -73,6 +79,8 @@ export interface EditTaskModalProps {
   setShowDeleteModal: (show: boolean) => void;
   setTodoToDelete: (todoId: string | null) => void;
   cancelEditing: () => void;
+  assignees?: string[];
+  setAssignees?: (ids: string[]) => void;
 }
 
 // DeleteConfirmationModal Component Types

--- a/app/types/join-space.ts
+++ b/app/types/join-space.ts
@@ -66,10 +66,18 @@ export interface AddTaskModalProps {
   setTitle: (title: string) => void;
   setTask: (task: string) => void;
   setPriority: (priority: 'low' | 'moderate' | 'high') => void;
-  handleAddTask: (e?: React.FormEvent<any>, assignedToArg?: string | null) => void;
+  handleAddTask: (e?: React.FormEvent<any>, assigneesArg?: string[]) => void;
   setShowInput: (show: boolean) => void;
   members?: Member[];
-  assignedTo?: string | null;
-  setAssignedTo?: (id: string | null) => void;
+  /** User ids assigned to the task being composed. */
+  assignees?: string[];
+  setAssignees?: (ids: string[]) => void;
   setDeadline: (date: Date | null) => void;
 }
+
+/** Normalizes Member.tbl_users, which the API returns as either an object or a
+ *  single-element array depending on the join. */
+export const memberUser = (
+  member: Member
+): { id?: string; full_name?: string } | undefined =>
+  Array.isArray(member.tbl_users) ? member.tbl_users[0] : member.tbl_users;

--- a/lib/auth/apiAuth.ts
+++ b/lib/auth/apiAuth.ts
@@ -1,0 +1,149 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Server-side auth helpers for API routes.
+ *
+ * Every route in this app talks to Supabase with the public anon key, so the
+ * database's RLS policies are the real enforcement layer (see
+ * sql/01_security_hardening.sql). These helpers do two things on top of that:
+ *
+ *   1. Build a Supabase client that carries the CALLER's access token, so RLS
+ *      evaluates `auth.uid()` as the real user instead of an anonymous session.
+ *   2. Verify membership/role before the handler runs, so the API returns a
+ *      clean 401/403 rather than a confusing empty result from a denied policy.
+ *
+ * Never trust a user id from the request body. Read it from the token.
+ */
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export function unauthorized(message = "Unauthorized") {
+  return NextResponse.json({ error: message }, { status: 401 });
+}
+
+export function forbidden(message = "Forbidden") {
+  return NextResponse.json({ error: message }, { status: 403 });
+}
+
+/** Pulls the bearer token off the request, if present. */
+function getAccessToken(request: NextRequest): string | null {
+  const header = request.headers.get("authorization");
+  if (header?.startsWith("Bearer ")) {
+    return header.slice("Bearer ".length).trim() || null;
+  }
+  return null;
+}
+
+/**
+ * A Supabase client scoped to the caller. Queries made through it run as that
+ * user, so RLS applies.
+ */
+export function getAuthedClient(accessToken?: string | null): SupabaseClient {
+  return createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    global: accessToken
+      ? { headers: { Authorization: `Bearer ${accessToken}` } }
+      : {},
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export interface AuthContext {
+  supabase: SupabaseClient;
+  userId: string;
+  accessToken: string;
+}
+
+type AuthResult<T> = T | { response: NextResponse };
+
+/**
+ * Verifies the caller's token and returns their user id. The token is validated
+ * against Supabase rather than decoded locally, so a forged or expired JWT is
+ * rejected.
+ */
+export async function requireUser(
+  request: NextRequest
+): Promise<AuthResult<AuthContext>> {
+  const accessToken = getAccessToken(request);
+  if (!accessToken) {
+    return { response: unauthorized("Missing access token") };
+  }
+
+  const supabase = getAuthedClient(accessToken);
+  const { data, error } = await supabase.auth.getUser(accessToken);
+
+  if (error || !data?.user) {
+    return { response: unauthorized("Invalid or expired session") };
+  }
+
+  return { supabase, userId: data.user.id, accessToken };
+}
+
+/** Verifies the caller is a member of the given space. */
+export async function requireSpaceMember(
+  request: NextRequest,
+  spaceId: string
+): Promise<AuthResult<AuthContext & { role: string }>> {
+  const auth = await requireUser(request);
+  if ("response" in auth) return auth;
+
+  const { data, error } = await auth.supabase
+    .from("tbl_space_members")
+    .select("role")
+    .eq("space_id", spaceId)
+    .eq("user_id", auth.userId)
+    .maybeSingle();
+
+  if (error) {
+    return { response: forbidden("Could not verify membership") };
+  }
+  if (!data) {
+    return { response: forbidden("You are not a member of this space") };
+  }
+
+  return { ...auth, role: data.role };
+}
+
+/** Verifies the caller is an admin of the given space. */
+export async function requireSpaceAdmin(
+  request: NextRequest,
+  spaceId: string
+): Promise<AuthResult<AuthContext & { role: string }>> {
+  const auth = await requireSpaceMember(request, spaceId);
+  if ("response" in auth) return auth;
+
+  if (auth.role !== "admin") {
+    return { response: forbidden("Admin role required") };
+  }
+  return auth;
+}
+
+/**
+ * Resolves a task id to its space and verifies the caller belongs to it. Used
+ * by PUT/DELETE, which receive only a task id.
+ */
+export async function requireTaskAccess(
+  request: NextRequest,
+  taskId: string
+): Promise<AuthResult<AuthContext & { spaceId: string; role: string }>> {
+  const auth = await requireUser(request);
+  if ("response" in auth) return auth;
+
+  const { data: task, error } = await auth.supabase
+    .from("tbl_tasks")
+    .select("id, space_id")
+    .eq("id", taskId)
+    .maybeSingle();
+
+  // A task in a space the caller cannot see is indistinguishable from a task
+  // that does not exist, which avoids leaking which ids are real.
+  if (error || !task) {
+    return { response: forbidden("Task not found or not accessible") };
+  }
+
+  const membership = await requireSpaceMember(request, task.space_id);
+  if ("response" in membership) return membership;
+
+  return { ...membership, spaceId: task.space_id };
+}


### PR DESCRIPTION
## Summary

Adds multi-assignee support for space tasks, and closes a set of access control
gaps found while implementing it.

The two are shipped together because they touch the same routes and are
interdependent at deploy time: the API now requires a bearer token, and the
database policies require the API to send one.

## Motivation

Tasks supported a single assignee, which does not match how the spaces are
actually used for group work.

While extending the task API, a review of the surrounding routes found that no
endpoint verified caller identity. Every route authenticated to Supabase with
`NEXT_PUBLIC_SUPABASE_ANON_KEY` — a value compiled into the client bundle and
therefore public — while Row Level Security was not enabled on any table. The
anon key is safe to publish only when RLS is on, because RLS is what constrains
it. Without RLS, and with handlers reading `userId` and `created_by` straight
from the request body, all space and task data was reachable by any caller.

## Changes

### Multi-assignee

- New `tbl_task_assignees` join table; one task can now carry any number of
  assignees.
- New `AssigneeSelect` component — checkbox dropdown with removable chips —
  used by both the add and edit task modals.
- Kanban cards show the first two assignees by name and roll the rest into a
  `+N` chip.
- The API validates every assignee id against the space roster before writing,
  so an arbitrary user id cannot be attached to a task.
- Assignment emails go to newly added assignees only, sent in parallel, and
  never block the response.

### Access control

- New `lib/auth/apiAuth.ts` with `requireUser`, `requireSpaceMember`,
  `requireSpaceAdmin`, and `requireTaskAccess`. Tokens are verified against
  Supabase rather than decoded locally.
- Admin role now required for: delete space, rename space, kick member, change
  member role.
- Membership now required for: read tasks, mutate tasks, read member roster.
- `join` enrolls the calling user only, always as `member`. `create` takes the
  creator from the session. `user-spaces` ignores any `userId` in the query.
- `/api/gemini` was an unauthenticated proxy to a paid API key with no rate
  limit. Now requires a session, caps prompts at 4,000 characters, and limits
  each user to 20 requests per hour.
- Task input is validated: priority and kanban status are allowlisted, title
  capped at 200 chars, description at 10,000.

### Fixes along the way

- Dragging a card between kanban columns resent the entire task object. With
  multi-assignee this would have cleared the assignee set on every drag; the
  handler now sends only the changed field, and omitted fields are left
  untouched by the API.
- `user-spaces` PATCH wrote to an `is_admin` column that nothing else reads. Now
  writes `role`.
- `editSpaceName` and `deleteSpace` sent parameters the API never read, so both
  were non-functional. Now send the expected body.
- Removed a stray character in `EditTaskModal` that rendered a literal `9` into
  the component tree.
- Added a guard preventing demotion of the last admin, which would otherwise
  leave a space unmanageable.

## Deployment

**The SQL must be applied before or with this merge. Code and database changes
are interdependent — deploying either alone breaks the app.**

Per this repo's convention, schema files are gitignored and not included in this
PR. Two files are required, in order:

1. `sql/01_security_hardening.sql` — enables RLS and adds membership-scoped
   policies across the seven tables, plus a `SECURITY DEFINER` function for
   join-by-code (needed because RLS hides `tbl_spaces` from non-members).
2. `sql/02_multi_assignee.sql` — creates `tbl_task_assignees`, backfills from
   the existing `assigned_to` column, and adds a sync trigger.

Before running: take a backup, and run the pre-flight `SELECT` at the top of
file 01 on its own to confirm the table names match the live schema. Enabling
RLS denies access by default, so a name mismatch means that table silently
returns nothing. File 01 ends with a verification query — every row should
report `rls_enabled = true`.

**Rotate the Gemini API key.** The endpoint was publicly callable, so the key
should be treated as compromised. Worth checking Google Cloud billing for
unexpected usage.

## Backward compatibility

`tbl_tasks.assigned_to` is retained and kept in sync by a database trigger, so
this is reversible and a partially-rolled-out frontend keeps working. Tasks
created before the migration fall back to that column when the edit modal seeds
its state. The column can be dropped once nothing reads it.

## Testing

`tsc --noEmit` and `next build` pass. Not yet verified against a live database —
the RLS policies should be applied to a non-production Supabase project first,
and the flows below exercised there.

Reviewer checklist:

- [x] Create a task with two or more assignees; confirm all receive email
- [x] Add and remove assignees on an existing task
- [x] Drag a card between kanban columns; confirm assignees survive
- [x] Open a task created before the migration; confirm its assignee appears
- [x] As a non-admin, confirm delete/rename/kick/role-change are rejected
- [x] With the anon key alone, confirm `/rest/v1/tbl_tasks` returns nothing

## Known gaps

- Email templates interpolate task titles and user names into HTML without
  escaping. Mail clients strip scripts so this is not stored XSS, but a crafted
  title can inject markup. Left for a follow-up as it needs a helper applied
  across all three templates.
- The Gemini rate limiter is in-memory, so it resets on redeploy and is
  per-instance. Move to Redis before scaling out.

There is no audit log, so it is not possible to determine whether any data was
accessed while these gaps were open.
